### PR TITLE
Adding a Viper plugin

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: monthly
+      day: monday
+    groups:
+      all:
+        patterns:
+          - "*"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,9 @@ on:
   merge_group: # run this workflow on every PR in the merge queue
   workflow_dispatch: # allow to manually trigger this workflow
 
+env:
+  java: 11
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -20,6 +23,13 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
+
+      - name: Set up Scala and JDK 1.${{ env.java }}
+        uses: olafurpg/setup-scala@v14
+        with:
+          # Should probably be changed to `temurin` once supported by `olafurpg/setup-scala`
+          # See https://github.com/actions/setup-java#supported-distributions
+          java-version: "adopt@1.${{ env.java }}"
 
       - name: Set sbt cache variables
         run: echo "SBT_OPTS=-Dsbt.global.base=sbt-cache/.sbtboot -Dsbt.boot.directory=sbt-cache/.boot -Dsbt.ivy.home=sbt-cache/.ivy" >> $GITHUB_ENV

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,42 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Copyright (c) 2011-2025 ETH Zurich.
+
+name: Build
+
+on:
+  push: # run this workflow on every push
+  pull_request: # run this workflow on every pull_request
+  merge_group: # run this workflow on every PR in the merge queue
+  workflow_dispatch: # allow to manually trigger this workflow
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Set sbt cache variables
+        run: echo "SBT_OPTS=-Dsbt.global.base=sbt-cache/.sbtboot -Dsbt.boot.directory=sbt-cache/.boot -Dsbt.ivy.home=sbt-cache/.ivy" >> $GITHUB_ENV
+        # note that the cache path is relative to the directory in which sbt is invoked.
+
+      - name: Cache SBT
+        uses: actions/cache@v4
+        with:
+          path: |
+            sbt-cache/.sbtboot
+            sbt-cache/.boot
+            sbt-cache/.ivy/cache
+          # <x>/project/target and <x>/target, where <x> is e.g. 'silver', are intentionally not
+          # included as several occurrences of NoSuchMethodError exceptions have been observed during CI runs. It seems
+          # like sbt is unable to correctly compute source files that require a recompilation. Therefore, we have
+          # disabled caching of compiled source files altogether
+          key: ${{ runner.os }}-sbt-no-precompiled-sources-${{ hashFiles('**/build.sbt') }}
+
+      - name: Build SIF plugin
+        run: sbt compile

--- a/.github/workflows/update-submodules.yml
+++ b/.github/workflows/update-submodules.yml
@@ -1,0 +1,57 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Copyright (c) 2011-2025 ETH Zurich.
+
+name: Update Submodules
+
+on:
+  workflow_dispatch: # allow to manually trigger this workflow
+  schedule:
+    - cron: '0 6 * * *' # run every day at 06:00 UTC
+
+jobs:
+  # Update the submodules and create a PR if there are any changes
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Get current commits
+        run: |
+          echo "PREV_SILVER_REF=$(git -C silver rev-parse HEAD)" >> $GITHUB_ENV
+
+      - name: Update Silver submodule
+        run: git checkout master && git pull
+        working-directory: silver
+
+      - name: Get new commits
+        run: |
+          echo "CUR_SILVER_REF=$(git -C silver rev-parse HEAD)" >> $GITHUB_ENV
+
+      - name: Open a pull request
+        id: pr
+        uses: peter-evans/create-pull-request@v7
+        if: env.PREV_SILVER_REF != env.CUR_SILVER_REF
+        with:
+          # Use viper-admin's token to workaround a restriction of GitHub.
+          # See: https://github.com/peter-evans/create-pull-request/issues/48
+          token: ${{ secrets.VIPER_ADMIN_TOKEN }}
+          commit-message: Updates submodules
+          title: Update Submodules
+          branch: auto-update-submodules
+          delete-branch: true
+          labels: |
+            automated pr
+          body: |
+            * Updates Silver from `${{ env.PREV_SILVER_REF }}` to `${{ env.CUR_SILVER_REF }}`.
+
+      - name: Enable auto-merge of PR
+        if: env.PREV_SILVER_REF != env.CUR_SILVER_REF
+        run: gh pr merge --merge --auto "${{ steps.pr.outputs.pull-request-number }}"
+        env:
+          GH_TOKEN: ${{ secrets.VIPER_ADMIN_TOKEN }}

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "silver"]
+	path = silver
+	url = https://github.com/viperproject/silver.git

--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,6 @@ ThisBuild / scalacOptions ++= Seq(
     "-feature",                         // Warn on features that requires explicit import
     "-Wunused",                         // Warn on unused imports
     "-Ypatmat-exhaust-depth", "40",     // Increase depth of pattern matching analysis
-    // "-Xfatal-warnings",                 // Treat Warnings as errors to guarantee code quality in future changes
 )
 
 // Enforce UTF-8, instead of relying on properly set locales

--- a/build.sbt
+++ b/build.sbt
@@ -4,6 +4,29 @@
 //
 // Copyright (c) 2011-2020 ETH Zurich.
 
+ThisBuild / scalaVersion := "2.13.10"
+ThisBuild / scalacOptions ++= Seq(
+    "-encoding", "UTF-8",               // Enforce UTF-8, instead of relying on properly set locales
+    "-deprecation",                     // Warn when using deprecated language features
+    "-unchecked",                       // Warn on generated code assumptions
+    "-feature",                         // Warn on features that requires explicit import
+    "-Wunused",                         // Warn on unused imports
+    "-Ypatmat-exhaust-depth", "40",     // Increase depth of pattern matching analysis
+    // "-Xfatal-warnings",                 // Treat Warnings as errors to guarantee code quality in future changes
+)
+
+// Enforce UTF-8, instead of relying on properly set locales
+ThisBuild / javacOptions ++= Seq("-encoding", "UTF-8", "-charset", "UTF-8", "-docencoding", "UTF-8")
+ThisBuild / javaOptions  ++= Seq("-Dfile.encoding=UTF-8")
+
+// Publishing settings
+
+// Allows 'publishLocal' SBT command to include test artifacts in a dedicated JAR file
+// (whose name is postfixed by 'test-source') and publish it in the local Ivy repository.
+// This JAR file contains all classes and resources for testing and projects like Carbon
+// and Silicon can rely on it to access the test suit implemented in Silver.
+ThisBuild / Test / publishArtifact := true
+
 // Import general settings from Silver
 lazy val silver = project in file("silver")
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,2 @@
-sbt.version=1.4.4
+sbt.version=1.6.2
 

--- a/src/main/scala/SIFAstExtensions.scala
+++ b/src/main/scala/SIFAstExtensions.scala
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 //
-// Copyright (c) 2011-2020 ETH Zurich.
+// Copyright (c) 2011-2025 ETH Zurich.
 
 package viper.silver.sif
 
@@ -10,7 +10,7 @@ package viper.silver.sif
 import viper.silver.ast.pretty.PrettyPrintPrimitives
 import viper.silver.ast.pretty.FastPrettyPrinter.{ContOps, nil, parens, show, showBlock, text}
 import viper.silver.ast._
-import viper.silver.verifier.VerificationResult
+import viper.silver.verifier.{ConsistencyError, Failure, VerificationResult}
 
 case class SIFReturnStmt(exp: Option[Exp], resVar: Option[LocalVar])
                         (val pos: Position = NoPosition,
@@ -117,7 +117,10 @@ case class SIFLowExp(exp: Exp, comparator: Option[String] = None, typVarMap: Map
 
   override def typ: Type = Bool
 
-  override def verifyExtExp(): VerificationResult = ???
+  override def verifyExtExp(): VerificationResult = {
+    assert(assertion = false, "SIFLowExp: verifyExtExp has not been implemented.")
+    Failure(Seq(ConsistencyError("SIFLowExp: verifyExtExp has not been implemented.", pos)))
+  }
 
   override def prettyPrint: PrettyPrintPrimitives#Cont = (if (comparator.isDefined) text("lowVal")
     else text("low")) <> parens(show(exp))
@@ -133,7 +136,10 @@ case class SIFRelExp(exp: Exp, i: IntLit)
 
   override def typ: Type = exp.typ
 
-  override def verifyExtExp(): VerificationResult = ???
+  override def verifyExtExp(): VerificationResult = {
+    assert(assertion = false, "SIFRelExp: verifyExtExp has not been implemented.")
+    Failure(Seq(ConsistencyError("SIFRelExp: verifyExtExp has not been implemented.", pos)))
+  }
 
   override def prettyPrint: PrettyPrintPrimitives#Cont = (text("rel") <> parens(show(exp) <> "," <+> show(i)))
 
@@ -147,7 +153,10 @@ case class SIFLowEventExp()(val pos: Position = NoPosition,
 
   override def typ: Type = Bool
 
-  override def verifyExtExp(): VerificationResult = ???
+  override def verifyExtExp(): VerificationResult = {
+    assert(assertion = false, "SIFLowEventExp: verifyExtExp has not been implemented.")
+    Failure(Seq(ConsistencyError("SIFLowEventExp: verifyExtExp has not been implemented.", pos)))
+  }
 
   override def prettyPrint: PrettyPrintPrimitives#Cont = text("lowEvent")
 
@@ -162,7 +171,10 @@ case class SIFLowExitExp()(val pos: Position = NoPosition,
 
   override def typ: Type = Bool
 
-  override def verifyExtExp(): VerificationResult = ???
+  override def verifyExtExp(): VerificationResult = {
+    assert(assertion = false, "SIFLowExitExp: verifyExtExp has not been implemented.")
+    Failure(Seq(ConsistencyError("SIFLowExitExp: verifyExtExp has not been implemented.", pos)))
+  }
 
   override def prettyPrint: PrettyPrintPrimitives#Cont = text("lowExit")
 
@@ -176,7 +188,10 @@ case class SIFTerminatesExp(cond: Exp)(val pos: Position = NoPosition,
 
   override def typ: Type = Bool
 
-  override def verifyExtExp(): VerificationResult = ???
+  override def verifyExtExp(): VerificationResult = {
+    assert(assertion = false, "SIFTerminatesExp: verifyExtExp has not been implemented.")
+    Failure(Seq(ConsistencyError("SIFTerminatesExp: verifyExtExp has not been implemented.", pos)))
+  }
 
   override def prettyPrint: PrettyPrintPrimitives#Cont =
     text("terminates under condition") <+> show(cond)

--- a/src/main/scala/SIFAstExtensions.scala
+++ b/src/main/scala/SIFAstExtensions.scala
@@ -125,6 +125,21 @@ case class SIFLowExp(exp: Exp, comparator: Option[String] = None, typVarMap: Map
   override val extensionIsPure: Boolean = exp.isPure
 }
 
+case class SIFRelExp(exp: Exp, i: IntLit)
+                    (val pos: Position = NoPosition,
+                     val info: Info = NoInfo,
+                     val errT: ErrorTrafo = NoTrafos) extends ExtensionExp {
+  override def extensionSubnodes: Seq[Node] = Seq(exp, i)
+
+  override def typ: Type = exp.typ
+
+  override def verifyExtExp(): VerificationResult = ???
+
+  override def prettyPrint: PrettyPrintPrimitives#Cont = (text("rel") <> parens(show(exp) <> "," <+> show(i)))
+
+  override val extensionIsPure: Boolean = exp.isPure
+}
+
 case class SIFLowEventExp()(val pos: Position = NoPosition,
                             val info: Info = NoInfo,
                             val errT: ErrorTrafo = NoTrafos) extends ExtensionExp {

--- a/src/main/scala/SIFAstExtensions.scala
+++ b/src/main/scala/SIFAstExtensions.scala
@@ -109,6 +109,12 @@ case class SIFAssertNoException()(val pos: Position = NoPosition,
   override def prettyPrint: PrettyPrintPrimitives#Cont = text("assert no exception")
 }
 
+/** Low(exp), i.e., exp is the same in both executions.
+  * Optionally, a comparator function can be given: This must be the name of a domain function that, with the given
+  * typVarMap (see DomainFuncApp), can be given two values of the type of exp and return a boolean.
+  * The intention is that low(exp) can be encoded as comparator(exp1, exp2) instead of exp1 == exp2, i.e.,
+  * the function can express a custom notion of equality.
+  */
 case class SIFLowExp(exp: Exp, comparator: Option[String] = None, typVarMap: Map[TypeVar, Type] = Map())
                     (val pos: Position = NoPosition,
                      val info: Info = NoInfo,
@@ -128,6 +134,10 @@ case class SIFLowExp(exp: Exp, comparator: Option[String] = None, typVarMap: Map
   override val extensionIsPure: Boolean = exp.isPure
 }
 
+
+/**
+  * Refers to the value of exp in execution i (must be 0 or 1).
+  */
 case class SIFRelExp(exp: Exp, i: IntLit)
                     (val pos: Position = NoPosition,
                      val info: Info = NoInfo,
@@ -146,6 +156,10 @@ case class SIFRelExp(exp: Exp, i: IntLit)
   override val extensionIsPure: Boolean = exp.isPure
 }
 
+/**
+  * Expresses that the current program point must be reached by both or no execution, i.e., whether it is reached
+  * is low.
+  */
 case class SIFLowEventExp()(val pos: Position = NoPosition,
                             val info: Info = NoInfo,
                             val errT: ErrorTrafo = NoTrafos) extends ExtensionExp {
@@ -164,6 +178,10 @@ case class SIFLowEventExp()(val pos: Position = NoPosition,
 
 }
 
+/**
+  * To be used only in loop invariants. States that if and when the loop is exited via a break or return is low,
+  * i.e., either both executions break or return in the same iteration, or both do not break or return at all.
+  */
 case class SIFLowExitExp()(val pos: Position = NoPosition,
                             val info: Info = NoInfo,
                             val errT: ErrorTrafo = NoTrafos) extends ExtensionExp {

--- a/src/main/scala/SIFError.scala
+++ b/src/main/scala/SIFError.scala
@@ -12,7 +12,7 @@ import viper.silver.verifier._
 
 
 case class SIFTerminationChannelCheckFailed(offendingNode: ErrorNode, reason: ErrorReason,
-                                            override val cached: Boolean = false) extends AbstractVerificationError {
+                                            override val cached: Boolean = false) extends ExtensionAbstractVerificationError {
   val id: String = "termination_channel_check.failed"
   val text: String = "Termination channel might exist."
   override def withNode(offendingNode: ErrorNode = this.offendingNode): ErrorMessage =
@@ -21,7 +21,7 @@ case class SIFTerminationChannelCheckFailed(offendingNode: ErrorNode, reason: Er
   override def withReason(r: ErrorReason): AbstractVerificationError = SIFTerminationChannelCheckFailed(offendingNode, r)
 }
 
-case class SIFFoldNotLow(offendingNode: Fold) extends AbstractErrorReason {
+case class SIFFoldNotLow(offendingNode: Fold) extends ExtensionAbstractErrorReason {
   val id: String = "sif.fold"
   val readableMessage: String = s"The low parts of predicate ${offendingNode.acc.loc.predicateName} might not hold."
 
@@ -29,7 +29,7 @@ case class SIFFoldNotLow(offendingNode: Fold) extends AbstractErrorReason {
     SIFFoldNotLow(offendingNode.asInstanceOf[Fold])
 }
 
-case class SIFUnfoldNotLow(offendingNode: Unfold) extends AbstractErrorReason {
+case class SIFUnfoldNotLow(offendingNode: Unfold) extends ExtensionAbstractErrorReason {
   val id: String = "sif.unfold"
   val readableMessage: String = s"The low parts of predicate ${offendingNode.acc.loc.predicateName} might not hold."
 
@@ -37,7 +37,7 @@ case class SIFUnfoldNotLow(offendingNode: Unfold) extends AbstractErrorReason {
     SIFUnfoldNotLow(offendingNode.asInstanceOf[Unfold])
 }
 
-case class SIFTermCondNotLow(offendingNode: SIFTerminatesExp) extends AbstractErrorReason {
+case class SIFTermCondNotLow(offendingNode: SIFTerminatesExp) extends ExtensionAbstractErrorReason {
   val id: String = "sif_termination.condition_not_low"
   val readableMessage: String = s"Termination condition ${offendingNode.cond} might not be low."
 
@@ -45,7 +45,7 @@ case class SIFTermCondNotLow(offendingNode: SIFTerminatesExp) extends AbstractEr
     SIFTermCondNotLow(offendingNode.asInstanceOf[SIFTerminatesExp])
 }
 
-case class SIFTermCondLowEvent(offendingNode: SIFTerminatesExp) extends AbstractErrorReason {
+case class SIFTermCondLowEvent(offendingNode: SIFTerminatesExp) extends ExtensionAbstractErrorReason {
   val id: String = "sif_termination.not_lowevent"
   val readableMessage: String =
     s"Termination condition ${offendingNode.cond} evaluating to false might not imply both executions don't terminate."
@@ -54,7 +54,7 @@ case class SIFTermCondLowEvent(offendingNode: SIFTerminatesExp) extends Abstract
     SIFTermCondLowEvent(offendingNode.asInstanceOf[SIFTerminatesExp])
 }
 
-case class SIFTermCondNotTight(offendingNode: SIFTerminatesExp) extends AbstractErrorReason {
+case class SIFTermCondNotTight(offendingNode: SIFTerminatesExp) extends ExtensionAbstractErrorReason {
   val id: String = "sif_termination.condition_not_tight"
   val readableMessage: String = s"Termination condition ${offendingNode.cond} might not be tight."
 

--- a/src/main/scala/SIFError.scala
+++ b/src/main/scala/SIFError.scala
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 //
-// Copyright (c) 2011-2020 ETH Zurich.
+// Copyright (c) 2011-2025 ETH Zurich.
 
 package viper.silver.sif
 

--- a/src/main/scala/SIFExtendedTransformer.scala
+++ b/src/main/scala/SIFExtendedTransformer.scala
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 //
-// Copyright (c) 2011-2020 ETH Zurich.
+// Copyright (c) 2011-2025 ETH Zurich.
 
 package viper.silver.sif
 
@@ -134,9 +134,8 @@ trait SIFExtendedTransformer {
       p.methods.map(m => translateMethod(m))
     }
 
-    val res = p.copy(domains = newDomains, fields = newFields, functions = newFunctions, predicates = newPredicates,
+    p.copy(domains = newDomains, fields = newFields, functions = newFunctions, predicates = newPredicates,
       methods = newMethods)(p.pos, p.info, p.errT)
-    res
   }
 
   def getName(orig: String) : String = {

--- a/src/main/scala/SIFExtendedTransformer.scala
+++ b/src/main/scala/SIFExtendedTransformer.scala
@@ -1271,7 +1271,8 @@ trait SIFExtendedTransformer {
     val relVars = e.filter{
       case _: SIFLowExp => true
       case _: SIFLowEventExp => true
-      case f@DomainFuncApp("Low", args, _) => true
+      case f@DomainFuncApp("Low", _, _) => true
+      case f@DomainFuncApp("LowEvent", Seq(), _) => true
       case _ => false
     }
     relVars.isEmpty
@@ -1395,6 +1396,8 @@ trait SIFExtendedTransformer {
       // for the domain method low, used e.g. for list resource
       case f@DomainFuncApp("Low", args, _) => translateSIFAss(
         SIFLowExp(args.head, None)(f.pos, f.info, f.errT), ctx, relAssertCtx)
+      case f@DomainFuncApp("LowEvent", Seq(), _) => translateSIFAss(
+        SIFLowEventExp()(f.pos, f.info, f.errT), ctx, relAssertCtx)
       case pap@PredicateAccessPredicate(pred, _) =>
         val (lowFunc, lhs) = getPredicateLowFuncExp(pred.predicateName, ctx, Some((p1, p2)))
         lowFunc match {
@@ -1451,6 +1454,7 @@ trait SIFExtendedTransformer {
         primedNames(name))(pa.pos, pa.info, pa.errT)
       case l: SIFLowExp => Implies(And(p1, p2)(), translateSIFLowExpComparison(l, p1, p2))()
       case f@DomainFuncApp("Low", args, _) => TrueLit()()
+      case f@DomainFuncApp("LowEvent", Seq(), _) => TrueLit()()
       case f@ForPerm(vars, location, body) => ForPerm(vars,
         translateResourceAccess(location),
         translatePrime(body, p1, p2))(f.pos, f.info, f.errT)
@@ -1475,7 +1479,8 @@ trait SIFExtendedTransformer {
   def translateToUnary(e: Exp): Exp = {
     val transformed = e.transform{
       case _: SIFLowExp => TrueLit()()
-      case f@DomainFuncApp("Low", args, _) => TrueLit()()
+      case DomainFuncApp("Low", args, _) => TrueLit()()
+      case DomainFuncApp("LowEvent", Seq(), _) => TrueLit()()
       case Implies(_: SIFLowExp, _: SIFLowExp) => TrueLit()()
       case i@Implies(lhs, rhs) => Implies(lhs, translateToUnary(rhs))(i.pos, i.info, i.errT)
     }

--- a/src/main/scala/SIFExtendedTransformer.scala
+++ b/src/main/scala/SIFExtendedTransformer.scala
@@ -516,15 +516,15 @@ trait SIFExtendedTransformer {
 
       val access1 = PredicateAccess(formalArgs.map{a => a.localVar}, pred1.name)(pred.pos)
       val access2 = PredicateAccess(duplicatedFormalArgs.map{a => a.localVar}, pred2.name)(pred.pos)
-      val fPres: Seq[Exp] = Seq(And(PredicateAccessPredicate(access1, WildcardPerm()())(),
-        PredicateAccessPredicate(access2, WildcardPerm()())())())
+      val fPres: Seq[Exp] = Seq(And(PredicateAccessPredicate(access1, None)(),
+        PredicateAccessPredicate(access2, None)())())
       val lowFFormalArgs = pred.formalArgs ++ duplicatedFormalArgs
       val primedBefore = primedNames.clone()
       formalArgs.zip(duplicatedFormalArgs).foreach(t => primedNames.update(t._1.name, t._2.name))
 
       def unfoldingPredicates(body: Exp): Exp = {
-        Unfolding(PredicateAccessPredicate(access1, WildcardPerm()())(),
-          Unfolding(PredicateAccessPredicate(access2, WildcardPerm()())(),
+        Unfolding(PredicateAccessPredicate(access1, None)(),
+          Unfolding(PredicateAccessPredicate(access2, None)(),
             body)())()
       }
       if (relationalPredicates.contains(pred)) {
@@ -1162,7 +1162,7 @@ trait SIFExtendedTransformer {
         }
         val if1 = If(act1, Seqn(Seq(u), Seq())(), skip)()
         val if2 = If(act2, Seqn(Seq(
-          Unfold(PredicateAccessPredicate(predicate2, translatePrime(acc.perm, p1, p2))())(u.pos, u.info, u.errT)
+          Unfold(PredicateAccessPredicate(predicate2, Some(translatePrime(acc.perm, p1, p2)))())(u.pos, u.info, u.errT)
         ), Seq())(), skip)()
         Seqn(Seq(assert, if1, if2), Seq())()
       case f@Fold(acc) =>
@@ -1170,7 +1170,7 @@ trait SIFExtendedTransformer {
         val if2 = If(act2, Seqn(Seq(
           Fold(PredicateAccessPredicate(
             PredicateAccess(acc.loc.args.map(a => translatePrime(a, p1, p2)),
-              primedNames(acc.loc.predicateName))(), translatePrime(acc.perm, p1, p2))())(f.pos, f.info, f.errT)
+              primedNames(acc.loc.predicateName))(), Some(translatePrime(acc.perm, p1, p2)))())(f.pos, f.info, f.errT)
         ), Seq())(), skip)()
         val (lowFunc, lhs) = getPredicateLowFuncExp(acc.loc.predicateName, ctx)
         val assert: Stmt = lowFunc match {

--- a/src/main/scala/SIFExtendedTransformer.scala
+++ b/src/main/scala/SIFExtendedTransformer.scala
@@ -134,8 +134,9 @@ trait SIFExtendedTransformer {
       p.methods.map(m => translateMethod(m))
     }
 
-    p.copy(domains = newDomains, fields = newFields, functions = newFunctions, predicates = newPredicates,
+    val res = p.copy(domains = newDomains, fields = newFields, functions = newFunctions, predicates = newPredicates,
       methods = newMethods)(p.pos, p.info, p.errT)
+    res
   }
 
   def getName(orig: String) : String = {
@@ -1271,6 +1272,7 @@ trait SIFExtendedTransformer {
     val relVars = e.filter{
       case _: SIFLowExp => true
       case _: SIFLowEventExp => true
+      case _: SIFRelExp => true
       case f@DomainFuncApp("Low", _, _) => true
       case f@DomainFuncApp("LowEvent", Seq(), _) => true
       case _ => false
@@ -1453,6 +1455,7 @@ trait SIFExtendedTransformer {
       case pa@PredicateAccess(args, name) => PredicateAccess(args.map(a => translatePrime(a, p1, p2)),
         primedNames(name))(pa.pos, pa.info, pa.errT)
       case l: SIFLowExp => Implies(And(p1, p2)(), translateSIFLowExpComparison(l, p1, p2))()
+      case SIFRelExp(e, i) => if(i.i == BigInt.int2bigInt(1)) translatePrime(e, p1, p2) else translateNormal(e, p1, p2)
       case f@DomainFuncApp("Low", args, _) => TrueLit()()
       case f@DomainFuncApp("LowEvent", Seq(), _) => TrueLit()()
       case f@ForPerm(vars, location, body) => ForPerm(vars,
@@ -1464,6 +1467,7 @@ trait SIFExtendedTransformer {
   def translateNormal[T <: Exp](e: T, p1: Exp, p2: Exp): T = {
     e.transform{
       case l: SIFLowExp => Implies(And(p1, p2)(), translateSIFLowExpComparison(l, p1, p2))()
+      case SIFRelExp(e, i) => if(i.i == BigInt.int2bigInt(1)) translatePrime(e, p1, p2) else translateNormal(e, p1, p2)
       case f@DomainFuncApp("Low", args, _) => Implies(And(p1, p2)(), translateSIFLowExpComparison(SIFLowExp(args.head)(), p1, p2))()
     }
   }

--- a/src/main/scala/SIFPAstExtensions.scala
+++ b/src/main/scala/SIFPAstExtensions.scala
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 //
-// Copyright (c) 2011-2020 ETH Zurich.
+// Copyright (c) 2011-2025 ETH Zurich.
 
 package viper.silver.sif
 
@@ -23,7 +23,7 @@ case class PLowExp(e: PExp)(val pos: (Position, Position) = (NoPosition, NoPosit
     if (expected == TypeHelper.Bool || expected == TypeHelper.Impure)
       None
     else
-      Some(Seq(s"Expected type ${expected}, but got Bool"))
+      Some(Seq(s"Expected type ${expected}, but got Bool."))
   }
 
   override def typecheck(t: TypeChecker, n: NameAnalyser): Option[Seq[String]] = {
@@ -49,7 +49,7 @@ case class PLowEventExp()(val pos: (Position, Position) = (NoPosition, NoPositio
     if (expected == TypeHelper.Bool || expected == TypeHelper.Impure)
       None
     else
-      Some(Seq(s"Expected type ${expected}, but got Bool"))
+      Some(Seq(s"Expected type ${expected}, but got Bool."))
   }
 
   override def translateExp(t: Translator): ExtensionExp = {
@@ -72,7 +72,7 @@ case class PRelExp(e: PExp, i: PIntLit)(val pos: (Position, Position) = (NoPosit
     if (i.i == BigInt.int2bigInt(0) || i.i == BigInt.int2bigInt(1))
       None
     else
-      Some(Seq(s"Second argument of rel must be 0 or 1, but is ${i.i}"))
+      Some(Seq(s"Second argument of rel must be 0 or 1, but is ${i.i}."))
   }
 
   override def typecheck(t: TypeChecker, n: NameAnalyser, expected: PType): Option[Seq[String]] = {
@@ -83,9 +83,9 @@ case class PRelExp(e: PExp, i: PIntLit)(val pos: (Position, Position) = (NoPosit
       if (expected == e.typ)
         None
       else
-        Some(Seq(s"Expected type ${expected}, but got ${e.typ}"))
+        Some(Seq(s"Expected type ${expected}, but got ${e.typ}."))
     } else {
-      Some(Seq(s"Second argument of rel must be 0 or 1, but is ${i.i}"))
+      Some(Seq(s"Second argument of rel must be 0 or 1, but is ${i.i}."))
     }
   }
 

--- a/src/main/scala/SIFPAstExtensions.scala
+++ b/src/main/scala/SIFPAstExtensions.scala
@@ -18,11 +18,9 @@ case class PLowExp(e: PExp)(val pos: (Position, Position) = (NoPosition, NoPosit
     e.forceSubstitution(ts)
   }
 
-  override val getSubnodes: Seq[PNode] = Seq(e)
-
   override def typecheck(t: TypeChecker, n: NameAnalyser, expected: PType): Option[Seq[String]] = {
     t.checkTopTyped(e, None)
-    if (expected == TypeHelper.Bool)
+    if (expected == TypeHelper.Bool || expected == TypeHelper.Impure)
       None
     else
       Some(Seq(s"Expected type ${expected}, but got Bool"))
@@ -45,12 +43,10 @@ case class PLowEventExp()(val pos: (Position, Position) = (NoPosition, NoPositio
 
   override def forceSubstitution(ts: PTypeSubstitution): Unit = {}
 
-  override val getSubnodes: Seq[PNode] = Seq()
-
   override def typecheck(t: TypeChecker, n: NameAnalyser): Option[Seq[String]] = None
 
   override def typecheck(t: TypeChecker, n: NameAnalyser, expected: PType): Option[Seq[String]] = {
-    if (expected == TypeHelper.Bool)
+    if (expected == TypeHelper.Bool || expected == TypeHelper.Impure)
       None
     else
       Some(Seq(s"Expected type ${expected}, but got Bool"))
@@ -68,8 +64,6 @@ case class PRelExp(e: PExp, i: PIntLit)(val pos: (Position, Position) = (NoPosit
   override def forceSubstitution(ts: PTypeSubstitution): Unit = {
     e.forceSubstitution(ts)
   }
-
-  override val getSubnodes: Seq[PNode] = Seq(e, i)
 
   override def typecheck(t: TypeChecker, n: NameAnalyser): Option[Seq[String]] = {
     t.checkTopTyped(e, None)

--- a/src/main/scala/SIFPAstExtensions.scala
+++ b/src/main/scala/SIFPAstExtensions.scala
@@ -1,0 +1,101 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2011-2020 ETH Zurich.
+
+package viper.silver.sif
+
+import viper.silver.ast.{ExtensionExp, IntLit, NoPosition, Position}
+import viper.silver.parser.{NameAnalyser, PExp, PExtender, PIntLit, PNode, PType, PTypeSubstitution, Translator, TypeChecker, TypeHelper}
+
+case class PLowExp(e: PExp)(val pos: (Position, Position) = (NoPosition, NoPosition)) extends PExtender with PExp {
+  typ = TypeHelper.Bool
+
+  override def typeSubstitutions = e.typeSubstitutions
+
+  override def forceSubstitution(ts: PTypeSubstitution): Unit = {
+    e.forceSubstitution(ts)
+  }
+
+  override val getSubnodes: Seq[PNode] = Seq(e)
+
+  override def typecheck(t: TypeChecker, n: NameAnalyser, expected: PType): Option[Seq[String]] = {
+    t.checkTopTyped(e, None)
+    if (expected == TypeHelper.Bool)
+      None
+    else
+      Some(Seq(s"Expected type ${expected}, but got Bool"))
+  }
+
+  override def typecheck(t: TypeChecker, n: NameAnalyser): Option[Seq[String]] = {
+    t.checkTopTyped(e, None)
+    None
+  }
+
+  override def translateExp(t: Translator): ExtensionExp = {
+    SIFLowExp(t.exp(e))(t.liftPos(this))
+  }
+}
+
+case class PLowEventExp()(val pos: (Position, Position) = (NoPosition, NoPosition)) extends PExtender with PExp {
+  typ = TypeHelper.Bool
+
+  override def typeSubstitutions = Seq()
+
+  override def forceSubstitution(ts: PTypeSubstitution): Unit = {}
+
+  override val getSubnodes: Seq[PNode] = Seq()
+
+  override def typecheck(t: TypeChecker, n: NameAnalyser): Option[Seq[String]] = None
+
+  override def typecheck(t: TypeChecker, n: NameAnalyser, expected: PType): Option[Seq[String]] = {
+    if (expected == TypeHelper.Bool)
+      None
+    else
+      Some(Seq(s"Expected type ${expected}, but got Bool"))
+  }
+
+  override def translateExp(t: Translator): ExtensionExp = {
+    SIFLowEventExp()(t.liftPos(this))
+  }
+}
+
+case class PRelExp(e: PExp, i: PIntLit)(val pos: (Position, Position) = (NoPosition, NoPosition)) extends PExtender with PExp {
+
+  override def typeSubstitutions = e.typeSubstitutions
+
+  override def forceSubstitution(ts: PTypeSubstitution): Unit = {
+    e.forceSubstitution(ts)
+  }
+
+  override val getSubnodes: Seq[PNode] = Seq(e, i)
+
+  override def typecheck(t: TypeChecker, n: NameAnalyser): Option[Seq[String]] = {
+    t.checkTopTyped(e, None)
+    t.checkTopTyped(i, Some(TypeHelper.Int))
+    typ = e.typ
+    if (i.i == BigInt.int2bigInt(0) || i.i == BigInt.int2bigInt(1))
+      None
+    else
+      Some(Seq(s"Second argument of rel must be 0 or 1, but is ${i.i}"))
+  }
+
+  override def typecheck(t: TypeChecker, n: NameAnalyser, expected: PType): Option[Seq[String]] = {
+    t.checkTopTyped(e, None)
+    t.checkTopTyped(i, Some(TypeHelper.Int))
+    typ = e.typ
+    if (i.i == BigInt.int2bigInt(0) || i.i == BigInt.int2bigInt(1)) {
+      if (expected == e.typ)
+        None
+      else
+        Some(Seq(s"Expected type ${expected}, but got ${e.typ}"))
+    } else {
+      Some(Seq(s"Second argument of rel must be 0 or 1, but is ${i.i}"))
+    }
+  }
+
+  override def translateExp(t: Translator): ExtensionExp = {
+    SIFRelExp(t.exp(e), t.exp(i).asInstanceOf[IntLit])(t.liftPos(this))
+  }
+}

--- a/src/main/scala/SIFPAstExtensions.scala
+++ b/src/main/scala/SIFPAstExtensions.scala
@@ -7,7 +7,7 @@
 package viper.silver.sif
 
 import viper.silver.ast.{ExtensionExp, IntLit, NoPosition, Position}
-import viper.silver.parser.{NameAnalyser, PExp, PExtender, PIntLit, PNode, PType, PTypeSubstitution, Translator, TypeChecker, TypeHelper}
+import viper.silver.parser.{NameAnalyser, PExp, PExtender, PIntLit, PType, PTypeSubstitution, Translator, TypeChecker, TypeHelper}
 
 case class PLowExp(e: PExp)(val pos: (Position, Position) = (NoPosition, NoPosition)) extends PExtender with PExp {
   typ = TypeHelper.Bool

--- a/src/main/scala/SIFPlugin.scala
+++ b/src/main/scala/SIFPlugin.scala
@@ -1,0 +1,39 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2011-2020 ETH Zurich.
+
+
+package viper.silver.sif
+
+import fastparse._
+import viper.silver.ast.Program
+import viper.silver.parser.FastParser
+import viper.silver.plugin.{ParserPluginTemplate, SilverPlugin}
+import viper.silver.parser.FastParserCompanion.whitespace
+
+import scala.annotation.unused
+
+class SIFPlugin(@unused reporter: viper.silver.reporter.Reporter,
+                @unused logger: ch.qos.logback.classic.Logger,
+                config: viper.silver.frontend.SilFrontendConfig,
+                fp: FastParser) extends SilverPlugin with ParserPluginTemplate {
+  import fp.{FP, exp, integer, ParserExtension}
+
+  def low[$: P]: P[PLowExp] = FP("low" ~ "(" ~ exp ~ ")").map { case (pos, e) => PLowExp(e)(pos) }
+  def rel[$: P]: P[PRelExp] = FP("rel" ~ "(" ~ exp ~ "," ~ integer ~ ")").map { case (pos, (e, i)) => PRelExp(e, i)(pos) }
+  def lowEvent[$: P]: P[PLowEventExp] = FP("lowEvent").map { case (pos, _) => PLowEventExp()(pos) }
+
+  override def beforeParse(input: String, isImported: Boolean): String = {
+    ParserExtension.addNewKeywords(Set[String]("low", "lowEvent", "rel"))
+    ParserExtension.addNewExpAtEnd(low(_))
+    ParserExtension.addNewExpAtEnd(rel(_))
+    ParserExtension.addNewExpAtEnd(lowEvent(_))
+    input
+  }
+
+  override def beforeVerify(input: Program): Program = {
+    SIFExtendedTransformer.transform(input, false)
+  }
+}

--- a/src/main/scala/SIFPlugin.scala
+++ b/src/main/scala/SIFPlugin.scala
@@ -11,7 +11,6 @@ import fastparse._
 import viper.silver.ast.Program
 import viper.silver.parser.{FastParser, PKeywordLang, PKw}
 import viper.silver.plugin.{ParserPluginTemplate, SilverPlugin}
-import viper.silver.parser.FastParserCompanion.whitespace
 
 import scala.annotation.unused
 
@@ -22,7 +21,7 @@ case object PRelKeyword extends PKw("rel") with PKeywordLang
 
 class SIFPlugin(@unused reporter: viper.silver.reporter.Reporter,
                 @unused logger: ch.qos.logback.classic.Logger,
-                config: viper.silver.frontend.SilFrontendConfig,
+                @unused config: viper.silver.frontend.SilFrontendConfig,
                 fp: FastParser) extends SilverPlugin with ParserPluginTemplate {
 
   import fp.{exp, integer, ParserExtension, lineCol, _file}

--- a/src/main/scala/SIFPlugin.scala
+++ b/src/main/scala/SIFPlugin.scala
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 //
-// Copyright (c) 2011-2020 ETH Zurich.
+// Copyright (c) 2011-2025 ETH Zurich.
 
 
 package viper.silver.sif


### PR DESCRIPTION
- Making the SIF transformation available via a plugin
- Defining a simple parser extension for that purpose
- Adding a ``SIFRelExp(e, i)`` expression that refers to the value of expression ``e`` in execution ``i``, where ``i`` is 0 or 1. @JonasAlaif asked for this.
- Bumping the SBT version
- Also adding something I added for Nagini ages a while ago, namely the possibility of using domain func apps to create low and lowEvent expressions.