### PR TITLE
Keep Node info during SIF transformation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "silver"]
+	path = silver
+	url = https://github.com/viperproject/silver.git

--- a/build.sbt
+++ b/build.sbt
@@ -4,6 +4,29 @@
 //
 // Copyright (c) 2011-2020 ETH Zurich.
 
+ThisBuild / scalaVersion := "2.13.10"
+ThisBuild / scalacOptions ++= Seq(
+    "-encoding", "UTF-8",               // Enforce UTF-8, instead of relying on properly set locales
+    "-deprecation",                     // Warn when using deprecated language features
+    "-unchecked",                       // Warn on generated code assumptions
+    "-feature",                         // Warn on features that requires explicit import
+    "-Wunused",                         // Warn on unused imports
+    "-Ypatmat-exhaust-depth", "40",     // Increase depth of pattern matching analysis
+    // "-Xfatal-warnings",                 // Treat Warnings as errors to guarantee code quality in future changes
+)
+
+// Enforce UTF-8, instead of relying on properly set locales
+ThisBuild / javacOptions ++= Seq("-encoding", "UTF-8", "-charset", "UTF-8", "-docencoding", "UTF-8")
+ThisBuild / javaOptions  ++= Seq("-Dfile.encoding=UTF-8")
+
+// Publishing settings
+
+// Allows 'publishLocal' SBT command to include test artifacts in a dedicated JAR file
+// (whose name is postfixed by 'test-source') and publish it in the local Ivy repository.
+// This JAR file contains all classes and resources for testing and projects like Carbon
+// and Silicon can rely on it to access the test suit implemented in Silver.
+ThisBuild / Test / publishArtifact := true
+
 // Import general settings from Silver
 lazy val silver = project in file("silver")
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,2 @@
-sbt.version=1.4.4
+sbt.version=1.6.2
 

--- a/src/main/scala/SIFAstExtensions.scala
+++ b/src/main/scala/SIFAstExtensions.scala
@@ -125,6 +125,21 @@ case class SIFLowExp(exp: Exp, comparator: Option[String] = None, typVarMap: Map
   override val extensionIsPure: Boolean = exp.isPure
 }
 
+case class SIFRelExp(exp: Exp, i: IntLit)
+                    (val pos: Position = NoPosition,
+                     val info: Info = NoInfo,
+                     val errT: ErrorTrafo = NoTrafos) extends ExtensionExp {
+  override def extensionSubnodes: Seq[Node] = Seq(exp, i)
+
+  override def typ: Type = exp.typ
+
+  override def verifyExtExp(): VerificationResult = ???
+
+  override def prettyPrint: PrettyPrintPrimitives#Cont = (text("rel") <> parens(show(exp) <> "," <+> show(i)))
+
+  override val extensionIsPure: Boolean = exp.isPure
+}
+
 case class SIFLowEventExp()(val pos: Position = NoPosition,
                             val info: Info = NoInfo,
                             val errT: ErrorTrafo = NoTrafos) extends ExtensionExp {

--- a/src/main/scala/SIFError.scala
+++ b/src/main/scala/SIFError.scala
@@ -12,7 +12,7 @@ import viper.silver.verifier._
 
 
 case class SIFTerminationChannelCheckFailed(offendingNode: ErrorNode, reason: ErrorReason,
-                                            override val cached: Boolean = false) extends AbstractVerificationError {
+                                            override val cached: Boolean = false) extends ExtensionAbstractVerificationError {
   val id: String = "termination_channel_check.failed"
   val text: String = "Termination channel might exist."
   override def withNode(offendingNode: ErrorNode = this.offendingNode): ErrorMessage =
@@ -21,7 +21,7 @@ case class SIFTerminationChannelCheckFailed(offendingNode: ErrorNode, reason: Er
   override def withReason(r: ErrorReason): AbstractVerificationError = SIFTerminationChannelCheckFailed(offendingNode, r)
 }
 
-case class SIFFoldNotLow(offendingNode: Fold) extends AbstractErrorReason {
+case class SIFFoldNotLow(offendingNode: Fold) extends ExtensionAbstractErrorReason {
   val id: String = "sif.fold"
   val readableMessage: String = s"The low parts of predicate ${offendingNode.acc.loc.predicateName} might not hold."
 
@@ -29,7 +29,7 @@ case class SIFFoldNotLow(offendingNode: Fold) extends AbstractErrorReason {
     SIFFoldNotLow(offendingNode.asInstanceOf[Fold])
 }
 
-case class SIFUnfoldNotLow(offendingNode: Unfold) extends AbstractErrorReason {
+case class SIFUnfoldNotLow(offendingNode: Unfold) extends ExtensionAbstractErrorReason {
   val id: String = "sif.unfold"
   val readableMessage: String = s"The low parts of predicate ${offendingNode.acc.loc.predicateName} might not hold."
 
@@ -37,7 +37,7 @@ case class SIFUnfoldNotLow(offendingNode: Unfold) extends AbstractErrorReason {
     SIFUnfoldNotLow(offendingNode.asInstanceOf[Unfold])
 }
 
-case class SIFTermCondNotLow(offendingNode: SIFTerminatesExp) extends AbstractErrorReason {
+case class SIFTermCondNotLow(offendingNode: SIFTerminatesExp) extends ExtensionAbstractErrorReason {
   val id: String = "sif_termination.condition_not_low"
   val readableMessage: String = s"Termination condition ${offendingNode.cond} might not be low."
 
@@ -45,7 +45,7 @@ case class SIFTermCondNotLow(offendingNode: SIFTerminatesExp) extends AbstractEr
     SIFTermCondNotLow(offendingNode.asInstanceOf[SIFTerminatesExp])
 }
 
-case class SIFTermCondLowEvent(offendingNode: SIFTerminatesExp) extends AbstractErrorReason {
+case class SIFTermCondLowEvent(offendingNode: SIFTerminatesExp) extends ExtensionAbstractErrorReason {
   val id: String = "sif_termination.not_lowevent"
   val readableMessage: String =
     s"Termination condition ${offendingNode.cond} evaluating to false might not imply both executions don't terminate."
@@ -54,7 +54,7 @@ case class SIFTermCondLowEvent(offendingNode: SIFTerminatesExp) extends Abstract
     SIFTermCondLowEvent(offendingNode.asInstanceOf[SIFTerminatesExp])
 }
 
-case class SIFTermCondNotTight(offendingNode: SIFTerminatesExp) extends AbstractErrorReason {
+case class SIFTermCondNotTight(offendingNode: SIFTerminatesExp) extends ExtensionAbstractErrorReason {
   val id: String = "sif_termination.condition_not_tight"
   val readableMessage: String = s"Termination condition ${offendingNode.cond} might not be tight."
 

--- a/src/main/scala/SIFExtendedTransformer.scala
+++ b/src/main/scala/SIFExtendedTransformer.scala
@@ -1289,7 +1289,7 @@ trait SIFExtendedTransformer {
 
   def translateSIFExp2(e: Exp, p1: Exp, p2: Exp): Exp = {
     e match {
-      case re if isRelational(e) => TrueLit()(e. pos, errT = fwTs(re, re))
+      case re if isRelational(e) => TrueLit()(e.pos, e.info, errT = fwTs(re, re))
       case _ => translatePrime(e, p1, p2)
     }
   }
@@ -1502,7 +1502,7 @@ trait SIFExtendedTransformer {
         val (lowFName, formalArgs, duplicatedFormalArgs) = predLowFuncInfo(loc.predicateName).get
         FuncApp(lowFName,
           loc.args ++ loc.args.map(a => translatePrime(a, null, null)))(
-          p.pos, NoInfo, Bool, p.errT)
+          p.pos, p.info, Bool, p.errT)
       case a@And(left, right) => And(translatePredLowFuncBody(left),
         translatePredLowFuncBody(right))(a.pos, a.info, a.errT)
       case o@Or(left, right) => Or(translatePredLowFuncBody(left),
@@ -1524,7 +1524,7 @@ trait SIFExtendedTransformer {
           val (lowFName, formalArgs, duplicatedFormalArgs) = predAllLowFuncInfo(loc.predicateName).get
           FuncApp(lowFName,
             loc.args ++ loc.args.map(a => translatePrime(a, null, null)))(
-            p.pos, NoInfo, Bool, p.errT)
+            p.pos, p.info, Bool, p.errT)
         }else{
           TrueLit()()
         }

--- a/src/main/scala/SIFExtendedTransformer.scala
+++ b/src/main/scala/SIFExtendedTransformer.scala
@@ -1271,7 +1271,8 @@ trait SIFExtendedTransformer {
     val relVars = e.filter{
       case _: SIFLowExp => true
       case _: SIFLowEventExp => true
-      case f@DomainFuncApp("Low", args, _) => true
+      case f@DomainFuncApp("Low", _, _) => true
+      case f@DomainFuncApp("LowEvent", Seq(), _) => true
       case _ => false
     }
     relVars.isEmpty
@@ -1395,6 +1396,8 @@ trait SIFExtendedTransformer {
       // for the domain method low, used e.g. for list resource
       case f@DomainFuncApp("Low", args, _) => translateSIFAss(
         SIFLowExp(args.head, None)(f.pos, f.info, f.errT), ctx, relAssertCtx)
+      case f@DomainFuncApp("LowEvent", Seq(), _) => translateSIFAss(
+        SIFLowEventExp()(f.pos, f.info, f.errT), ctx, relAssertCtx)
       case pap@PredicateAccessPredicate(pred, _) =>
         val (lowFunc, lhs) = getPredicateLowFuncExp(pred.predicateName, ctx, Some((p1, p2)))
         lowFunc match {
@@ -1451,6 +1454,7 @@ trait SIFExtendedTransformer {
         primedNames(name))(pa.pos, pa.info, pa.errT)
       case l: SIFLowExp => Implies(And(p1, p2)(), translateSIFLowExpComparison(l, p1, p2))()
       case f@DomainFuncApp("Low", args, _) => TrueLit()()
+      case f@DomainFuncApp("LowEvent", Seq(), _) => TrueLit()()
       case f@ForPerm(vars, location, body) => ForPerm(vars,
         translateResourceAccess(location),
         translatePrime(body, p1, p2))(f.pos, f.info, f.errT)
@@ -1475,7 +1479,8 @@ trait SIFExtendedTransformer {
   def translateToUnary(e: Exp): Exp = {
     val transformed = e.transform{
       case _: SIFLowExp => TrueLit()()
-      case f@DomainFuncApp("Low", args, _) => TrueLit()()
+      case DomainFuncApp("Low", args, _) => TrueLit()()
+      case DomainFuncApp("LowEvent", Seq(), _) => TrueLit()()
       case Implies(_: SIFLowExp, _: SIFLowExp) => TrueLit()()
       case i@Implies(lhs, rhs) => Implies(lhs, translateToUnary(rhs))(i.pos, i.info, i.errT)
     }

--- a/src/main/scala/SIFExtendedTransformer.scala
+++ b/src/main/scala/SIFExtendedTransformer.scala
@@ -318,14 +318,14 @@ trait SIFExtendedTransformer {
     primedNamesPerMethod.update(m.name, primedNames.toMap)
     primedNames.clear()
     primedNames ++= primedBefore
-    Method(m.name, newArgs, newReturns, newPres, newPosts, newBody)(m.pos)
+    Method(m.name, newArgs, newReturns, newPres, newPosts, newBody)(m.pos, m.info)
   }
 
   def _conjoinOptions(in: Seq[Option[Exp]]): Exp = {
     val defined = in.filter(x => x.isDefined).map(x => x.get)
     defined.size match {
       case 0 => TrueLit()()
-      case _ => defined.reduceRight((a, b) => And(a, b)(a.pos))
+      case _ => defined.reduceRight((a, b) => And(a, b)(a.pos, a.info))
     }
   }
 
@@ -345,9 +345,9 @@ trait SIFExtendedTransformer {
       case FieldAccessPredicate(loc, _) => Seq(loc)
     })).flatten.distinct
     for (fieldAcc <- allFieldAccesses) {
-      val eq = SIFLowExp(fieldAcc, None)(m.pos)
+      val eq = SIFLowExp(fieldAcc, None)(m.pos, m.info)
       if (old)
-        lowExpressions :+= Old(eq)(m.pos)
+        lowExpressions :+= Old(eq)(m.pos, m.info)
       else
         lowExpressions :+= eq
     }
@@ -358,13 +358,13 @@ trait SIFExtendedTransformer {
         val funcApp = FuncApp(predAllLowFuncs(loc.predicateName).get,
           loc.args ++ loc.args.map(a => translatePrime(a, null, null)))()
         if (old)
-          Old(funcApp)(m.pos)
+          Old(funcApp)(m.pos, m.info)
         else
           funcApp
     })
 
     if (lowExpressions.nonEmpty)
-      Some(lowExpressions.reduceRight[Exp]((a, b) => And(a, b)(m.pos)))
+      Some(lowExpressions.reduceRight[Exp]((a, b) => And(a, b)(m.pos, m.info)))
     else
       None
   }
@@ -383,7 +383,7 @@ trait SIFExtendedTransformer {
     if (allLowMethods.contains(m.name)) newPosts :+= allVarsAndStateLow(m, m.formalReturns, old = false, predicateSrc = m.posts)
     if (preservesLowMethods.contains(m.name)) newPosts :+= Implies(
       allVarsAndStateLow(m, m.formalArgs, old = true, predicateSrc = m.pres),
-      allVarsAndStateLow(m, m.formalReturns, old = false, predicateSrc = m.posts))(m.pos)
+      allVarsAndStateLow(m, m.formalReturns, old = false, predicateSrc = m.posts))(m.pos, m.info)
     (newPres, newPosts)
   }
 
@@ -514,8 +514,8 @@ trait SIFExtendedTransformer {
     if (pred.body.isDefined) {
       val (allLowFName, formalArgs, duplicatedFormalArgs) = predAllLowFuncInfo(pred.name).get
 
-      val access1 = PredicateAccess(formalArgs.map{a => a.localVar}, pred1.name)(pred.pos)
-      val access2 = PredicateAccess(duplicatedFormalArgs.map{a => a.localVar}, pred2.name)(pred.pos)
+      val access1 = PredicateAccess(formalArgs.map{a => a.localVar}, pred1.name)(pred.pos, pred.info)
+      val access2 = PredicateAccess(duplicatedFormalArgs.map{a => a.localVar}, pred2.name)(pred.pos, pred.info)
       val fPres: Seq[Exp] = Seq(And(PredicateAccessPredicate(access1, WildcardPerm()())(),
         PredicateAccessPredicate(access2, WildcardPerm()())())())
       val lowFFormalArgs = pred.formalArgs ++ duplicatedFormalArgs
@@ -1054,10 +1054,10 @@ trait SIFExtendedTransformer {
         val (p3d, p3r) = getNewBool("p3")
         val (p4d, p4r) = getNewBool("p4")
 
-        val p1Assign = LocalVarAssign(p1r, And(act1, cond)())(i.pos)
-        val p2Assign = LocalVarAssign(p2r, And(act2, translatePrime(cond, p1, p2))())(i.pos)
-        val p3Assign = LocalVarAssign(p3r, And(act1, Not(cond)())())(i.pos)
-        val p4Assign = LocalVarAssign(p4r, And(act2, Not(translatePrime(cond, p1, p2))())())(i.pos)
+        val p1Assign = LocalVarAssign(p1r, And(act1, cond)())(i.pos, i.info)
+        val p2Assign = LocalVarAssign(p2r, And(act2, translatePrime(cond, p1, p2))())(i.pos, i.info)
+        val p3Assign = LocalVarAssign(p3r, And(act1, Not(cond)())())(i.pos, i.info)
+        val p4Assign = LocalVarAssign(p4r, And(act2, Not(translatePrime(cond, p1, p2))())())(i.pos, i.info)
 
         val thnRes = translateStatement(thn, TranslationContext(p1r, p2r, ctrlVars, ctx.currentMethod))
         val elsRes = translateStatement(els, TranslationContext(p3r, p4r, ctrlVars, ctx.currentMethod))
@@ -1135,11 +1135,11 @@ trait SIFExtendedTransformer {
             p2 = ctrlVars.activeExecNoContPrime(Some(p2)))
           case _ => ctx.copy(p1 = act1, p2 = act2)
         }
-        Assert(translateSIFAss(e1, newCtx))(s.pos, errT= fwTs(s, s))
+        Assert(translateSIFAss(e1, newCtx))(s.pos, s.info, errT= fwTs(s, s))
       case i@Inhale(FalseLit()) => i
-      case Assume(e1) => Assume(translateSIFAss(e1, ctx.copy(p1 = act1, p2 = act2)))(s.pos, errT= fwTs(s, s))
-      case Inhale(e1) => Inhale(translateSIFAss(e1, ctx.copy(p1 = act1, p2 = act2)))(s.pos, errT= fwTs(s, s))
-      case Exhale(e1) => Exhale(translateSIFAss(e1, ctx.copy(p1 = act1, p2 = act2)))(s.pos, errT= fwTs(s, s))
+      case Assume(e1) => Assume(translateSIFAss(e1, ctx.copy(p1 = act1, p2 = act2)))(s.pos, s.info, errT= fwTs(s, s))
+      case Inhale(e1) => Inhale(translateSIFAss(e1, ctx.copy(p1 = act1, p2 = act2)))(s.pos, s.info, errT= fwTs(s, s))
+      case Exhale(e1) => Exhale(translateSIFAss(e1, ctx.copy(p1 = act1, p2 = act2)))(s.pos, s.info, errT= fwTs(s, s))
       case d : LocalVarDeclStmt => d
       case u@Unfold(acc) =>
         val predicate2 = PredicateAccess(acc.loc.args.map(a => translatePrime(a, p1, p2)),
@@ -1282,7 +1282,7 @@ trait SIFExtendedTransformer {
 
   def translateSIFExp1(e: Exp, p1: Exp, p2: Exp): Exp = {
     e match {
-      case re if isRelational(e) => Implies(And(p1, p2)(), translateNormal(e, p1, p2))(e.pos, errT = fwTs(re, re))
+      case re if isRelational(e) => Implies(And(p1, p2)(), translateNormal(e, p1, p2))(e.pos, e.info, errT = fwTs(re, re))
       case re if isUnary(e) => translateNormal(e, p1, p2)
     }
   }
@@ -1297,7 +1297,7 @@ trait SIFExtendedTransformer {
   def translateSIFLowExpComparison(l: SIFLowExp, p1: Exp, p2: Exp): Exp = {
     val primedExp = translatePrime(l.exp, p1, p2)
     l.comparator match {
-      case None => EqCmp(l.exp, primedExp)(l.pos, errT = fwTs(l, l))
+      case None => EqCmp(l.exp, primedExp)(l.pos, l.info, errT = fwTs(l, l))
       case Some(str) =>
         _program.findDomainFunctionOptionally(str) match {
           case Some(df) => DomainFuncApp(df, Seq(l.exp, primedExp), l.typVarMap)(l.pos, l.info, errT = fwTs(l, l))
@@ -1310,8 +1310,8 @@ trait SIFExtendedTransformer {
   }
 
   def translateAssDefault(e: Exp, p1: Exp, p2: Exp): And = {
-    And(Implies(p1, translateSIFExp1(e, p1, p2))(e.pos, errT = fwTs(e, e)),
-      Implies(p2, translateSIFExp2(e, p1, p2))(e.pos, errT = fwTs(e, e)))(e.pos, errT = fwTs(e, e))
+    And(Implies(p1, translateSIFExp1(e, p1, p2))(e.pos, e.info, errT = fwTs(e, e)),
+      Implies(p2, translateSIFExp2(e, p1, p2))(e.pos, e.info, errT = fwTs(e, e)))(e.pos, e.info, errT = fwTs(e, e))
   }
 
   def fwTs(t: TransformableErrors, node: ErrorNode) = {
@@ -1328,9 +1328,9 @@ trait SIFExtendedTransformer {
     }
 
     e match {
-      case And(e1, e2) => And(translateSIFAss(e1, ctx, relAssertCtx), translateSIFAss(e2, ctx, relAssertCtx))(e.pos, errT = fwTs(e, e))
+      case And(e1, e2) => And(translateSIFAss(e1, ctx, relAssertCtx), translateSIFAss(e2, ctx, relAssertCtx))(e.pos, e.info, errT = fwTs(e, e))
       case i@Implies(e1, e2) if !isUnary(i) => {
-        Implies(translateSIFAss(e1, ctx, relAssertCtx), translateSIFAss(e2, ctx, relAssertCtx))(e.pos, errT = fwTs(e, e))
+        Implies(translateSIFAss(e1, ctx, relAssertCtx), translateSIFAss(e2, ctx, relAssertCtx))(e.pos, e.info, errT = fwTs(e, e))
       }
       case Implies(e1, e2) if e2.exists({
         case PredicateAccess(_, name) => predLowFuncs(name).isDefined
@@ -1357,12 +1357,12 @@ trait SIFExtendedTransformer {
           val newTriggers = triggers.map{t => Trigger(t.exps.map{e => translatePrime(e, p1, p2)})()}
           //val res = Forall(vars ++ pvars, newTriggers, Implies(varEqs, translateSIFAss(exp, p1, p2))(e.pos, errT = NodeTrafo(e)))(e.pos, errT = NodeTrafo(e))
           val res = Forall(vars, triggers ++ newTriggers,
-            translateSIFAss(exp, ctx, relAssertCtx))(e.pos, errT = fwTs(e, e)).autoTrigger
+            translateSIFAss(exp, ctx, relAssertCtx))(e.pos, e.info, errT = fwTs(e, e)).autoTrigger
           res
         } else {
           val normal = translateNormal(fa, p1, p2)
           val prime = translatePrime(fa, p1, p2)
-          And(Implies(p1, normal)(e.pos, errT = fwTs(e, e)), Implies(p2, prime)(e.pos, errT = fwTs(e, e)))(e.pos, errT = fwTs(e, e))
+          And(Implies(p1, normal)(e.pos, e.info, errT = fwTs(e, e)), Implies(p2, prime)(e.pos, e.info, errT = fwTs(e, e)))(e.pos, e.info, errT = fwTs(e, e))
         }
       }
       case l: SIFLowEventExp =>
@@ -1370,20 +1370,20 @@ trait SIFExtendedTransformer {
         val act2 = ctx.ctrlVars.activeExecPrime(Some(p2))
         val dynCheckInfo = l.info.getUniqueInfo[SIFDynCheckInfo]
         dynCheckInfo match {
-          case None => EqCmp(act1, act2)(e.pos, errT = fwTs(e, e))
-          case Some(dci) => And(EqCmp(act1, act2)(e.pos, errT = fwTs(e, e)), Implies(act1,
+          case None => EqCmp(act1, act2)(e.pos, e.info, errT = fwTs(e, e))
+          case Some(dci) => And(EqCmp(act1, act2)(e.pos, e.info, errT = fwTs(e, e)), Implies(act1,
             EqCmp(translateNormal(dci.dynCheck, p1, p2),
-              translatePrime(dci.dynCheck, p1, p2))())())(e.pos, errT = fwTs(e, e))
+              translatePrime(dci.dynCheck, p1, p2))())())(e.pos, e.info, errT = fwTs(e, e))
         }
       case l: SIFLowExitExp =>
         val act1 = ctx.ctrlVars.activeExecNoContNormal(None)
         val act2 = ctx.ctrlVars.activeExecNoContPrime(None)
-        Implies(And(relCtx.p1, relCtx.p2)(), EqCmp(act1, act2)(e.pos, errT = fwTs(e, e)))(e.pos, errT = fwTs(e, e))
+        Implies(And(relCtx.p1, relCtx.p2)(), EqCmp(act1, act2)(e.pos, e.info, errT = fwTs(e, e)))(e.pos, e.info, errT = fwTs(e, e))
       case l@SIFLowExp(_, _, _) =>
         val comparison = translateSIFLowExpComparison(l, relCtx.p1, relCtx.p2)
         val dynCheckInfo = l.info.getUniqueInfo[SIFDynCheckInfo]
         dynCheckInfo match {
-          case None => bothExecutions(comparison, e.pos)
+          case None => bothExecutions(comparison, e.pos, e.info)
           case Some(dci) =>
             val inhalePart = bothExecutions(Implies(
               EqCmp(translateNormal(dci.dynCheck, relCtx.p1, relCtx.p2), translatePrime(dci.dynCheck, relCtx.p1, relCtx.p2))(), comparison
@@ -1391,7 +1391,7 @@ trait SIFExtendedTransformer {
             if (dci.onlyDynVersion) {
               inhalePart
             } else {
-              InhaleExhaleExp(inhalePart, bothExecutions(comparison, e.pos)
+              InhaleExhaleExp(inhalePart, bothExecutions(comparison, e.pos, e.info)
               )(l.pos, l.info, errT = fwTs(l, l))
             }
         }
@@ -1418,7 +1418,7 @@ trait SIFExtendedTransformer {
                 else InhaleExhaleExp(inhalePart, lowFuncApp)(e.pos, e.info, e.errT)
               case None => lowFuncApp
             }
-            And(translateAssDefault(pap, p1, p2), lowPart)(e.pos, errT = fwTs(e, e))
+            And(translateAssDefault(pap, p1, p2), lowPart)(e.pos, e.info, errT = fwTs(e, e))
           case None => translateAssDefault(pap, p1, p2)
         }
       case o@Old(oldExp) => Old(translateSIFAss(oldExp, ctx, relAssertCtx))(o.pos, o.info, o.errT)
@@ -1442,7 +1442,7 @@ trait SIFExtendedTransformer {
         l.copy(name = primedNames(l.name))(l.pos, l.info, l.errT)
       case l: LocalVar if !primedNames.contains(l.name) => l
       case FieldAccess(rcv, field) =>
-        FieldAccess(translatePrime(rcv, p1, p2), newFields.find(f => f.name == primedNames(field.name)).get)(e.pos)
+        FieldAccess(translatePrime(rcv, p1, p2), newFields.find(f => f.name == primedNames(field.name)).get)(e.pos, e.info)
       case f@FuncApp(name, _) if Config.primedFuncAppReplacements.keySet.contains(name) =>
         Config.primedFuncAppReplacements(name)(f, p1, p2)
       case f@FuncApp(name, args) if primedNames.contains(name) => FuncApp(primedNames(name),

--- a/src/main/scala/SIFExtendedTransformer.scala
+++ b/src/main/scala/SIFExtendedTransformer.scala
@@ -134,8 +134,9 @@ trait SIFExtendedTransformer {
       p.methods.map(m => translateMethod(m))
     }
 
-    p.copy(domains = newDomains, fields = newFields, functions = newFunctions, predicates = newPredicates,
+    val res = p.copy(domains = newDomains, fields = newFields, functions = newFunctions, predicates = newPredicates,
       methods = newMethods)(p.pos, p.info, p.errT)
+    res
   }
 
   def getName(orig: String) : String = {
@@ -1271,6 +1272,7 @@ trait SIFExtendedTransformer {
     val relVars = e.filter{
       case _: SIFLowExp => true
       case _: SIFLowEventExp => true
+      case _: SIFRelExp => true
       case f@DomainFuncApp("Low", _, _) => true
       case f@DomainFuncApp("LowEvent", Seq(), _) => true
       case _ => false
@@ -1453,6 +1455,7 @@ trait SIFExtendedTransformer {
       case pa@PredicateAccess(args, name) => PredicateAccess(args.map(a => translatePrime(a, p1, p2)),
         primedNames(name))(pa.pos, pa.info, pa.errT)
       case l: SIFLowExp => Implies(And(p1, p2)(), translateSIFLowExpComparison(l, p1, p2))()
+      case SIFRelExp(e, i) => if(i.i == BigInt.int2bigInt(1)) translatePrime(e, p1, p2) else translateNormal(e, p1, p2)
       case f@DomainFuncApp("Low", args, _) => TrueLit()()
       case f@DomainFuncApp("LowEvent", Seq(), _) => TrueLit()()
       case f@ForPerm(vars, location, body) => ForPerm(vars,
@@ -1464,6 +1467,7 @@ trait SIFExtendedTransformer {
   def translateNormal[T <: Exp](e: T, p1: Exp, p2: Exp): T = {
     e.transform{
       case l: SIFLowExp => Implies(And(p1, p2)(), translateSIFLowExpComparison(l, p1, p2))()
+      case SIFRelExp(e, i) => if(i.i == BigInt.int2bigInt(1)) translatePrime(e, p1, p2) else translateNormal(e, p1, p2)
       case f@DomainFuncApp("Low", args, _) => Implies(And(p1, p2)(), translateSIFLowExpComparison(SIFLowExp(args.head)(), p1, p2))()
     }
   }

--- a/src/main/scala/SIFPAstExtensions.scala
+++ b/src/main/scala/SIFPAstExtensions.scala
@@ -17,16 +17,14 @@ case object PLowEventKeyword extends PKw("lowEvent") with PKeywordLang
 case class PLowExp(e: PGrouped.Paren[PExp])(val pos: (Position, Position) = (NoPosition, NoPosition)) extends PExtender with PExp {
   typ = TypeHelper.Bool
 
-  override def typeSubstitutions = e.typeSubstitutions
+  override def typeSubstitutions = e.inner.typeSubstitutions
 
   override def forceSubstitution(ts: PTypeSubstitution): Unit = {
-    e.forceSubstitution(ts)
+    e.inner.forceSubstitution(ts)
   }
 
-  override val getSubnodes: Seq[PNode] = Seq(e)
-
   override def typecheck(t: TypeChecker, n: NameAnalyser, expected: PType): Option[Seq[String]] = {
-    t.checkTopTyped(e, None)
+    t.checkTopTyped(e.inner, None)
     if (expected == TypeHelper.Bool)
       None
     else
@@ -34,12 +32,12 @@ case class PLowExp(e: PGrouped.Paren[PExp])(val pos: (Position, Position) = (NoP
   }
 
   override def typecheck(t: TypeChecker, n: NameAnalyser): Option[Seq[String]] = {
-    t.checkTopTyped(e, None)
+    t.checkTopTyped(e.inner, None)
     None
   }
 
   override def translateExp(t: Translator): ExtensionExp = {
-    SIFLowExp(t.exp(e))(t.liftPos(this))
+    SIFLowExp(t.exp(e.inner))(t.liftPos(this))
   }
 }
 
@@ -49,8 +47,6 @@ case class PLowEventExp()(val pos: (Position, Position) = (NoPosition, NoPositio
   override def typeSubstitutions = Seq()
 
   override def forceSubstitution(ts: PTypeSubstitution): Unit = {}
-
-  override val getSubnodes: Seq[PNode] = Seq()
 
   override def typecheck(t: TypeChecker, n: NameAnalyser): Option[Seq[String]] = None
 
@@ -73,8 +69,6 @@ case class PRelExp(e: PExp, i: PIntLit)(val pos: (Position, Position) = (NoPosit
   override def forceSubstitution(ts: PTypeSubstitution): Unit = {
     e.forceSubstitution(ts)
   }
-
-  override val getSubnodes: Seq[PNode] = Seq(e, i)
 
   override def typecheck(t: TypeChecker, n: NameAnalyser): Option[Seq[String]] = {
     t.checkTopTyped(e, None)

--- a/src/main/scala/SIFPAstExtensions.scala
+++ b/src/main/scala/SIFPAstExtensions.scala
@@ -1,0 +1,101 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2011-2020 ETH Zurich.
+
+package viper.silver.sif
+
+import viper.silver.ast.{ExtensionExp, IntLit, NoPosition, Position}
+import viper.silver.parser.{NameAnalyser, PExp, PExtender, PIntLit, PNode, PType, PTypeSubstitution, Translator, TypeChecker, TypeHelper}
+
+case class PLowExp(e: PExp)(val pos: (Position, Position) = (NoPosition, NoPosition)) extends PExtender with PExp {
+  typ = TypeHelper.Bool
+
+  override def typeSubstitutions = e.typeSubstitutions
+
+  override def forceSubstitution(ts: PTypeSubstitution): Unit = {
+    e.forceSubstitution(ts)
+  }
+
+  override val getSubnodes: Seq[PNode] = Seq(e)
+
+  override def typecheck(t: TypeChecker, n: NameAnalyser, expected: PType): Option[Seq[String]] = {
+    t.checkTopTyped(e, None)
+    if (expected == TypeHelper.Bool)
+      None
+    else
+      Some(Seq(s"Expected type ${expected}, but got Bool"))
+  }
+
+  override def typecheck(t: TypeChecker, n: NameAnalyser): Option[Seq[String]] = {
+    t.checkTopTyped(e, None)
+    None
+  }
+
+  override def translateExp(t: Translator): ExtensionExp = {
+    SIFLowExp(t.exp(e))(t.liftPos(this))
+  }
+}
+
+case class PLowEventExp()(val pos: (Position, Position) = (NoPosition, NoPosition)) extends PExtender with PExp {
+  typ = TypeHelper.Bool
+
+  override def typeSubstitutions = Seq()
+
+  override def forceSubstitution(ts: PTypeSubstitution): Unit = {}
+
+  override val getSubnodes: Seq[PNode] = Seq()
+
+  override def typecheck(t: TypeChecker, n: NameAnalyser): Option[Seq[String]] = None
+
+  override def typecheck(t: TypeChecker, n: NameAnalyser, expected: PType): Option[Seq[String]] = {
+    if (expected == TypeHelper.Bool)
+      None
+    else
+      Some(Seq(s"Expected type ${expected}, but got Bool"))
+  }
+
+  override def translateExp(t: Translator): ExtensionExp = {
+    SIFLowEventExp()(t.liftPos(this))
+  }
+}
+
+case class PRelExp(e: PExp, i: PIntLit)(val pos: (Position, Position) = (NoPosition, NoPosition)) extends PExtender with PExp {
+
+  override def typeSubstitutions = e.typeSubstitutions
+
+  override def forceSubstitution(ts: PTypeSubstitution): Unit = {
+    e.forceSubstitution(ts)
+  }
+
+  override val getSubnodes: Seq[PNode] = Seq(e, i)
+
+  override def typecheck(t: TypeChecker, n: NameAnalyser): Option[Seq[String]] = {
+    t.checkTopTyped(e, None)
+    t.checkTopTyped(i, Some(TypeHelper.Int))
+    typ = e.typ
+    if (i.i == BigInt.int2bigInt(0) || i.i == BigInt.int2bigInt(1))
+      None
+    else
+      Some(Seq(s"Second argument of rel must be 0 or 1, but is ${i.i}"))
+  }
+
+  override def typecheck(t: TypeChecker, n: NameAnalyser, expected: PType): Option[Seq[String]] = {
+    t.checkTopTyped(e, None)
+    t.checkTopTyped(i, Some(TypeHelper.Int))
+    typ = e.typ
+    if (i.i == BigInt.int2bigInt(0) || i.i == BigInt.int2bigInt(1)) {
+      if (expected == e.typ)
+        None
+      else
+        Some(Seq(s"Expected type ${expected}, but got ${e.typ}"))
+    } else {
+      Some(Seq(s"Second argument of rel must be 0 or 1, but is ${i.i}"))
+    }
+  }
+
+  override def translateExp(t: Translator): ExtensionExp = {
+    SIFRelExp(t.exp(e), t.exp(i).asInstanceOf[IntLit])(t.liftPos(this))
+  }
+}

--- a/src/main/scala/SIFPAstExtensions.scala
+++ b/src/main/scala/SIFPAstExtensions.scala
@@ -6,10 +6,15 @@
 
 package viper.silver.sif
 
-import viper.silver.ast.{ExtensionExp, IntLit, NoPosition, Position}
-import viper.silver.parser.{NameAnalyser, PExp, PExtender, PIntLit, PNode, PType, PTypeSubstitution, Translator, TypeChecker, TypeHelper}
+import viper.silver.ast._
+import viper.silver.parser._
 
-case class PLowExp(e: PExp)(val pos: (Position, Position) = (NoPosition, NoPosition)) extends PExtender with PExp {
+case object PLowKeyword extends PKw("low") with PKeywordLang
+case object PRelKeyword extends PKw("rel") with PKeywordLang
+case object PLowEventKeyword extends PKw("lowEvent") with PKeywordLang
+
+
+case class PLowExp(e: PGrouped.Paren[PExp])(val pos: (Position, Position) = (NoPosition, NoPosition)) extends PExtender with PExp {
   typ = TypeHelper.Bool
 
   override def typeSubstitutions = e.typeSubstitutions

--- a/src/main/scala/SIFPlugin.scala
+++ b/src/main/scala/SIFPlugin.scala
@@ -1,0 +1,39 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2011-2020 ETH Zurich.
+
+
+package viper.silver.sif
+
+import fastparse._
+import viper.silver.ast.Program
+import viper.silver.parser.FastParser
+import viper.silver.plugin.{ParserPluginTemplate, SilverPlugin}
+import viper.silver.parser.FastParserCompanion.whitespace
+
+import scala.annotation.unused
+
+class SIFPlugin(@unused reporter: viper.silver.reporter.Reporter,
+                @unused logger: ch.qos.logback.classic.Logger,
+                config: viper.silver.frontend.SilFrontendConfig,
+                fp: FastParser) extends SilverPlugin with ParserPluginTemplate {
+  import fp.{FP, exp, integer, ParserExtension}
+
+  def low[$: P]: P[PLowExp] = FP("low" ~ "(" ~ exp ~ ")").map { case (pos, e) => PLowExp(e)(pos) }
+  def rel[$: P]: P[PRelExp] = FP("rel" ~ "(" ~ exp ~ "," ~ integer ~ ")").map { case (pos, (e, i)) => PRelExp(e, i)(pos) }
+  def lowEvent[$: P]: P[PLowEventExp] = FP("lowEvent").map { case (pos, _) => PLowEventExp()(pos) }
+
+  override def beforeParse(input: String, isImported: Boolean): String = {
+    ParserExtension.addNewKeywords(Set[String]("low", "lowEvent", "rel"))
+    ParserExtension.addNewExpAtEnd(low(_))
+    ParserExtension.addNewExpAtEnd(rel(_))
+    ParserExtension.addNewExpAtEnd(lowEvent(_))
+    input
+  }
+
+  override def beforeVerify(input: Program): Program = {
+    SIFExtendedTransformer.transform(input, false)
+  }
+}

--- a/src/main/scala/SIFPlugin.scala
+++ b/src/main/scala/SIFPlugin.scala
@@ -19,7 +19,7 @@ class SIFPlugin(@unused reporter: viper.silver.reporter.Reporter,
                 @unused logger: ch.qos.logback.classic.Logger,
                 config: viper.silver.frontend.SilFrontendConfig,
                 fp: FastParser) extends SilverPlugin with ParserPluginTemplate {
-  import fp.{integer, exp, ParserExtension, parenthesizedExp}
+  import fp.{integer, exp, ParserExtension, parenthesizedExp, lineCol, _file}
   import FastParserCompanion.{ExtendedParsing, LeadingWhitespace, PositionParsing, reservedKw, reservedSym}
 
   def condition[$: P]: P[(PReserved[PLowKeyword.type], PExp)] = P(P(PLowKeyword) ~ exp)


### PR DESCRIPTION
Keeps the info from the nodes during the SIF transformation. Needed for Verifiers that use the info field such as VerCors.

Branched from silver-sif-extension/latest-viper-release (last commit 9442d82e4a152b696d953aa7f179d2b7c2a77ebe)